### PR TITLE
Descriptive::Usage should be a subclass of G::L::D::Usage

### DIFF
--- a/lib/CLI/Osprey/Descriptive/Usage.pm
+++ b/lib/CLI/Osprey/Descriptive/Usage.pm
@@ -8,7 +8,7 @@ use overload (
   q{""} => "text",
 );
 
-use Getopt::Long::Descriptive::Usage ();
+extends 'Getopt::Long::Descriptive::Usage';
 
 # ABSTRACT: Produce usage information for CLI::Osprey apps
 # VERSION


### PR DESCRIPTION
Fixes unknown options dying with

Can't locate object method "die" via package "CLI::Osprey::Descriptive::Usage"

Seems to have gotten lost in e730ec25.