### PR TITLE
Usage api

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -3,3 +3,9 @@ requires 'Moo::Role';
 requires 'Getopt::Long::Descriptive';
 requires 'Module::Runtime';
 requires 'Path::Tiny';
+
+on 'test' => sub {
+   requires 'Test2::V0';
+   requires 'Test::Lib';
+   requires 'Capture::Tiny';
+};

--- a/lib/CLI/Osprey/Descriptive/Usage.pm
+++ b/lib/CLI/Osprey/Descriptive/Usage.pm
@@ -10,6 +10,8 @@ use overload (
 
 use Getopt::Long::Descriptive::Usage ();
 
+*option_text = \&Getopt::Long::Descriptive::Usage::option_text;
+
 # ABSTRACT: Produce usage information for CLI::Osprey apps
 # VERSION
 # AUTHORITY
@@ -318,5 +320,15 @@ sub option_pod {
   return join("\n\n", @pod);
 }
 
+sub die  {
+  my $self = shift;
+  my $arg  = shift || {};
+
+  die(
+    join q{}, grep { defined } $arg->{pre_text}, $self->text, $arg->{post_text}
+  );
+}
+
+sub warn { warn shift->text }
 
 1;

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,0 +1,46 @@
+#! perl
+
+use Test2::V0;
+use Capture::Tiny qw( capture );
+
+use Test::Lib;
+use MyTest::Class::Basic;
+
+subtest 'command' => sub {
+
+    subtest "default options" => sub {
+	local @ARGV = ();
+	my ( $stdout, $stderr, @result ) =
+	   capture { MyTest::Class::Basic->new_with_options->run };
+
+	is ( $stdout, "Hello world!\n", "message sent to stdout" );
+	is ( $stderr, '', "empty stderr" );
+
+    };
+
+    subtest "command line options" => sub {
+	local @ARGV = ( '--message', 'Hello Cleveland!' );
+	my ( $stdout, $stderr, @result ) =
+	   capture { MyTest::Class::Basic->new_with_options->run };
+
+	is ( $stdout, "Hello Cleveland!\n", "message sent to stdout" );
+	is ( $stderr, '', "empty stderr" );
+
+    };
+
+};
+
+subtest 'subcommand' => sub {
+
+    subtest "default options" => sub {
+	local @ARGV = qw ( yell );
+	my ( $stdout, $stderr, @result ) =
+	   capture { MyTest::Class::Basic->new_with_options->run };
+
+	is ( $stdout, "HELLO WORLD!\n", "message sent to stdout" );
+	is ( $stderr, '', "empty stderr" );
+    };
+
+};
+
+done_testing;

--- a/t/lib/MyTest/Class/Basic.pm
+++ b/t/lib/MyTest/Class/Basic.pm
@@ -1,0 +1,20 @@
+package MyTest::Class::Basic;
+
+use Moo;
+use CLI::Osprey;
+
+option 'message' => (
+    is => 'ro',
+    format => 's',
+    doc => 'The message to display',
+    default => 'Hello world!',
+);
+
+subcommand yell => 'MyTest::Class::Basic::Yell';
+
+sub run {
+    my ($self) = @_;
+    print $self->message, "\n";
+}
+
+1;

--- a/t/lib/MyTest/Class/Basic/Yell.pm
+++ b/t/lib/MyTest/Class/Basic/Yell.pm
@@ -1,0 +1,12 @@
+package MyTest::Class::Basic::Yell;
+
+use Moo;
+use CLI::Osprey;
+
+sub run {
+    my ($self) = @_;
+    print uc $self->parent_command->message, "\n";
+}
+
+
+1;

--- a/t/usage_api.t
+++ b/t/usage_api.t
@@ -1,0 +1,22 @@
+#! perl
+
+use Test2::V0;
+
+use CLI::Osprey::Descriptive::Usage;
+
+can_ok(
+    'CLI::Osprey::Descriptive::Usage',
+       'new',
+       'text',
+       'leader_text',
+       'warn',
+       'die',
+
+       # option_text() is part of the Getopt::Long::Descriptive::Usage API, but
+       # seems only to be used within ::Usage, so maybe it doesn't need
+       # to be implemented?
+       # 'option_text',
+);
+
+
+done_testing;


### PR DESCRIPTION
This adds two of the three missing methods (`die` & `warn`) to the `Usage` module.  They are essentially copied over from `Getopt::Long::Descriptive::Usage`.  It doesn't deal with `option_text`, as that seems to have been used only inside of `Getopt::Long::Descriptive::Usage`.

It adds an api completeness test.