### PR TITLE
allow storage of repeated option values in a hash

### DIFF
--- a/lib/CLI/Osprey.pm
+++ b/lib/CLI/Osprey.pm
@@ -15,7 +15,7 @@ use Moo::Role qw(); # only want class methods, not setting up a role
 use CLI::Osprey::InlineSubcommand ();
 
 my @OPTIONS_ATTRIBUTES = qw(
-  option option_name format short repeatable negatable spacer_before spacer_after doc long_doc format_doc order hidden
+  option option_name format short repeatable negatable spacer_before spacer_after doc long_doc format_doc order hidden keyvalue
 );
 
 sub import {
@@ -419,6 +419,14 @@ Default: B<false>.
 A C<hidden> option will be recognized, but not listed in automatically generated
 documentation.
 
+=head2 keyvalue
+
+Default: B<false>
+
+If both L</keyvalue> and L</repeatable> are true, the option's values
+are stored in a hash rather than an array. The value specified for the
+option should be of the form I<key>C<=>I<value>.
+
 =head2 negatable
 
 Default: B<false>.
@@ -459,7 +467,9 @@ Default: B<false>.
 Allows an option to be specified more than once. When used on a "boolean"
 option with no L</format>, each appearace of the option will increment the value
 by 1 (equivalent to C<+> in L<Getopt::Long>. When used on an option with
-arguments, produces an arrayref, one value per appearance of the option.
+arguments, it produces an arrayref if L</keyvalue> is false, or a hashref
+if L</keyvalue> is true. one entry per appearance of the option.  If L</keyvalue>
+is true, the value specified for the option should be of the form I<key>C<=>I<value>
 
 =head2 required
 

--- a/lib/CLI/Osprey/Role.pm
+++ b/lib/CLI/Osprey/Role.pm
@@ -17,7 +17,8 @@ sub _osprey_option_to_getopt {
   $getopt .= '+' if $attributes{repeatable} && !defined $attributes{format};
   $getopt .= '!' if $attributes{negatable};
   $getopt .= '=' . $attributes{format} if defined $attributes{format};
-  $getopt .= '@' if $attributes{repeatable} && defined $attributes{format};
+  $getopt .= $attributes{keyvalue} ? '%' : '@'
+    if $attributes{repeatable} && defined $attributes{format};
   return $getopt;
 }
 

--- a/t/option_spec.t
+++ b/t/option_spec.t
@@ -36,6 +36,14 @@ use Test::Fatal;
     repeatable => 1,
   );
 
+  option repeatable_kv_string => (
+    is         => 'ro',
+    option     => 'kvstring',
+    format     => 's',
+    repeatable => 1,
+    keyvalue   => 1,
+  );
+
   option integer => (
     is     => 'ro',
     format => 'i'
@@ -73,23 +81,53 @@ subtest string => sub {
     is( App->new_with_options->string, 'foo', 'standard string' );
   }
 
-  {
-    local @ARGV = ();
-    is( App->new_with_options->repeatable_string,
-      undef, 'repeatable string, 0 entries' );
-  }
+  subtest 'repeatable string as array' => sub {
 
-  {
-    local @ARGV = qw( --rstring=foo );
-    is_deeply( App->new_with_options->repeatable_string,
-      ['foo'], 'repeatable string, 1 entries' );
-  }
+    {
+      local @ARGV = ();
+      is( App->new_with_options->repeatable_string,
+	undef, 'repeatable string, 0 entries' );
+    }
 
-  {
-    local @ARGV = qw( --rstring=foo --rstring=bar );
-    is_deeply( App->new_with_options->repeatable_string,
-      [qw( foo bar )], 'repeatable string, 2 entries' );
-  }
+    {
+      local @ARGV = qw( --rstring=foo );
+      is_deeply( App->new_with_options->repeatable_string,
+	['foo'], 'repeatable string, 1 entries' );
+    }
+
+    {
+      local @ARGV = qw( --rstring=foo --rstring=bar );
+      is_deeply( App->new_with_options->repeatable_string,
+	[qw( foo bar )], 'repeatable string, 2 entries' );
+    }
+  };
+
+  subtest 'repeatable string as key value' => sub {
+
+    {
+      local @ARGV = ();
+      is( App->new_with_options->repeatable_kv_string,
+	undef, 'key value string, 0 entries' );
+    }
+
+    {
+      local @ARGV = qw( --kvstring foo=bar );
+      is_deeply(
+	App->new_with_options->repeatable_kv_string,
+	{ foo => 'bar' },
+	'key value string, 1 entries'
+      );
+    }
+
+    {
+      local @ARGV = qw( --kvstring foo=bar --kvstring bar=baz );
+      is_deeply(
+	App->new_with_options->repeatable_kv_string,
+	{ foo => 'bar', bar => 'baz' },
+	'repeatable string, 2 entries'
+      );
+    }
+  };
 
 };
 

--- a/t/option_spec.t
+++ b/t/option_spec.t
@@ -1,0 +1,112 @@
+#! perl
+
+use Test::More;
+use Test::Fatal;
+
+{
+  package App;
+
+  use Moo;
+  use CLI::Osprey;
+
+  option bool => ( is => 'ro', );
+
+  option negatable_bool => (
+    is        => 'ro',
+    option    => 'nbool',
+    default   => !!1,
+    negatable => 1,
+  );
+
+  option repeatable_bool => (
+    is         => 'ro',
+    option     => 'rbool',
+    repeatable => 1,
+  );
+
+  option string => (
+    is     => 'ro',
+    format => 's'
+  );
+
+  option repeatable_string => (
+    is         => 'ro',
+    option     => 'rstring',
+    format     => 's',
+    repeatable => 1,
+  );
+
+  option integer => (
+    is     => 'ro',
+    format => 'i'
+  );
+
+  option float => (
+    is     => 'ro',
+    format => 'f',
+  );
+
+}
+
+subtest bool => sub {
+
+  {
+    local @ARGV = qw( --bool );
+    is( !!App->new_with_options->bool, !!1, 'standard bool' );
+  }
+
+  {
+    local @ARGV = qw( --no-nbool );
+    is( !!App->new_with_options->negatable_bool, !!0, 'negatable bool' );
+  }
+
+  {
+    local @ARGV = qw( --rbool --rbool --rbool );
+    is( App->new_with_options->repeatable_bool, 3, 'repeatable bool' );
+  }
+};
+
+subtest string => sub {
+
+  {
+    local @ARGV = qw( --string=foo );
+    is( App->new_with_options->string, 'foo', 'standard string' );
+  }
+
+  {
+    local @ARGV = ();
+    is( App->new_with_options->repeatable_string,
+      undef, 'repeatable string, 0 entries' );
+  }
+
+  {
+    local @ARGV = qw( --rstring=foo );
+    is_deeply( App->new_with_options->repeatable_string,
+      ['foo'], 'repeatable string, 1 entries' );
+  }
+
+  {
+    local @ARGV = qw( --rstring=foo --rstring=bar );
+    is_deeply( App->new_with_options->repeatable_string,
+      [qw( foo bar )], 'repeatable string, 2 entries' );
+  }
+
+};
+
+subtest integer => sub {
+
+  {
+    local @ARGV = qw( --integer=1 );
+    is( App->new_with_options->integer, 1, 'integer' );
+  }
+
+  {
+    local $SIG{__WARN__} = sub { die @_ };
+    local @ARGV = qw( --integer=foo );
+    like( exception { App->new_with_options->integer },
+      qr/invalid/, 'bad value', );
+  }
+
+};
+
+done_testing;


### PR DESCRIPTION
This commit adds an option attribute `keyvalue`.  When true, repeated options are stored in a hash rather than an array.  This simply adds support for Getopt::Long's `%` desttype.

It also adds some tests for the option specification.