### PR TITLE
only load subcommand when invoked

### DIFF
--- a/lib/CLI/Osprey.pm
+++ b/lib/CLI/Osprey.pm
@@ -100,8 +100,6 @@ sub import {
         method => $subobject,
         @args,
       );
-    } else {
-      use_module($subobject);
     }
 
     $subcommands->{$name} = $subobject;

--- a/lib/CLI/Osprey.pm
+++ b/lib/CLI/Osprey.pm
@@ -101,6 +101,9 @@ sub import {
         @args,
       );
     }
+    else {
+        use_module($subobject) unless $osprey_config->{on_demand};
+    }
 
     $subcommands->{$name} = $subobject;
     $apply_modifiers->();
@@ -364,6 +367,16 @@ Default: C<"USAGE: $program_name %o">
 Provides the header of the usage message printed in response to the C<-h>
 option or an error in option processing. The format of the string is described
 in L<Getopt::Long::Descriptive/"$usage_desc">.
+
+=head2 on_demand
+
+Default: false
+
+If set to a true value, the commands' modules won't be loaded
+at compile time, but if the command is invoked. This is useful for
+minimizing compile time if the application has a lot of commands or
+the commands are on the heavy side. Note that enabling the feature
+may interfere with the ability to fatpack the application.
 
 =head1 OPTION PARAMETERS
 

--- a/lib/CLI/Osprey/Role.pm
+++ b/lib/CLI/Osprey/Role.pm
@@ -4,6 +4,7 @@ use warnings;
 use Carp 'croak';
 use Path::Tiny ();
 use Scalar::Util qw(blessed);
+use Module::Runtime 'use_module';
 
 use CLI::Osprey::Descriptive;
 
@@ -192,11 +193,15 @@ sub new_with_options {
     return $class->osprey_usage(1, $usage);
   }
 
-  if ($subcommand_class) {
-    return $subcommand_class->new_with_options(%params, parent_command => $self, invoked_as => "$params{invoked_as} $subcommand_name");
-  } else {
-    return $self;
-  }
+  return $self unless $subcommand_class;
+
+  use_module($subcommand_class);
+
+  return $subcommand_class->new_with_options(
+      %params,
+      parent_command => $self,
+      invoked_as => "$params{invoked_as} $subcommand_name"
+  );
 }
 
 sub parse_options {

--- a/t/lib/OnDemand.pm
+++ b/t/lib/OnDemand.pm
@@ -1,7 +1,7 @@
 package OnDemand;
 
 use Moo;
-use CLI::Osprey;
+use CLI::Osprey on_demand => $::on_demand;
 
 subcommand foo => 'OnDemand::Foo';
 subcommand bar => 'OnDemand::Bar';

--- a/t/lib/OnDemand.pm
+++ b/t/lib/OnDemand.pm
@@ -1,0 +1,11 @@
+package OnDemand;
+
+use Moo;
+use CLI::Osprey;
+
+subcommand foo => 'OnDemand::Foo';
+subcommand bar => 'OnDemand::Bar';
+
+sub run { }
+
+1;

--- a/t/lib/OnDemand/Bar.pm
+++ b/t/lib/OnDemand/Bar.pm
@@ -1,0 +1,10 @@
+package OnDemand::Bar;
+
+use Moo;
+use CLI::Osprey;
+
+$OnDemand::Bar::loaded = 1;
+
+sub run { }
+
+1;

--- a/t/lib/OnDemand/Foo.pm
+++ b/t/lib/OnDemand/Foo.pm
@@ -1,0 +1,10 @@
+package OnDemand::Foo;
+
+use Moo;
+use CLI::Osprey;
+
+$OnDemand::Foo::loaded = 1;
+
+sub run { }
+
+1;

--- a/t/load-on-use.t
+++ b/t/load-on-use.t
@@ -4,6 +4,7 @@ use warnings;
 use Test::More;
 use lib 't/lib';
 
+BEGIN { $::on_demand = 1; }
 use OnDemand;
 
 plan tests => 4;

--- a/t/load-on-use.t
+++ b/t/load-on-use.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+
+use Test::More;
+use lib 't/lib';
+
+use OnDemand;
+
+plan tests => 4;
+
+subtest 'no subcommand loaded at the start' => sub {
+    ok !$OnDemand::Foo::loaded;
+    ok !$OnDemand::Bar::loaded;
+};
+
+
+subtest 'created object, still no subcommand loaded' => sub {
+    OnDemand->new_with_options;
+
+    ok !$OnDemand::Foo::loaded;
+    ok !$OnDemand::Bar::loaded;
+};
+
+subtest 'app ran, still no subcommand loaded' => sub {
+    OnDemand->new_with_options->run;
+
+    ok !$OnDemand::Foo::loaded;
+    ok !$OnDemand::Bar::loaded;
+};
+
+subtest 'app ran w/ subcommand foo, only foo loaded' => sub {
+    @ARGV = qw/ foo /;
+    OnDemand->new_with_options->run;
+
+    ok $OnDemand::Foo::loaded;
+    ok !$OnDemand::Bar::loaded;
+};

--- a/t/loaded-by-default.t
+++ b/t/loaded-by-default.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+
+use Test::More;
+use lib 't/lib';
+
+use OnDemand;
+
+plan tests => 4;
+
+subtest 'subcommand loaded at the start' => sub {
+    ok $OnDemand::Foo::loaded;
+    ok $OnDemand::Bar::loaded;
+};
+
+subtest 'created object, subcommand still loaded' => sub {
+    OnDemand->new_with_options;
+
+    ok $OnDemand::Foo::loaded;
+    ok $OnDemand::Bar::loaded;
+};
+
+subtest 'app ran, subcommand still loaded' => sub {
+    OnDemand->new_with_options->run;
+
+    ok $OnDemand::Foo::loaded;
+    ok $OnDemand::Bar::loaded;
+};
+
+subtest 'app ran w/ subcommand foo' => sub {
+    @ARGV = qw/ foo /;
+    OnDemand->new_with_options->run;
+
+    ok $OnDemand::Foo::loaded;
+    ok $OnDemand::Bar::loaded;
+};


### PR DESCRIPTION
Instead of `use`ing all the subcommands
at declaration, only `use` it when invoked.
That should help performance when dealing with
an app with lots of subcommands (or with a few
very fat subcommands).