### PR TITLE
Test inline subcommand and fix regression

### DIFF
--- a/lib/CLI/Osprey/Role.pm
+++ b/lib/CLI/Osprey/Role.pm
@@ -199,7 +199,7 @@ sub new_with_options {
 
   return $self unless $subcommand_class;
 
-  use_module($subcommand_class);
+  use_module($subcommand_class) unless ref $subcommand_class;
 
   return $subcommand_class->new_with_options(
       %params,

--- a/t/basic.t
+++ b/t/basic.t
@@ -41,6 +41,15 @@ subtest 'subcommand' => sub {
 	is ( $stderr, '', "empty stderr" );
     };
 
+    subtest "inline" => sub {
+	local @ARGV = qw ( whisper );
+	my ( $stdout, $stderr, @result ) =
+	   capture { MyTest::Class::Basic->new_with_options->run };
+
+	is ( $stdout, "hello world!\n", "message sent to stdout" );
+	is ( $stderr, '', "empty stderr" );
+    };
+
 };
 
 done_testing;

--- a/t/lib/MyTest/Class/Basic.pm
+++ b/t/lib/MyTest/Class/Basic.pm
@@ -12,6 +12,11 @@ option 'message' => (
 
 subcommand yell => 'MyTest::Class::Basic::Yell';
 
+subcommand whisper => sub {
+    my ($self) = @_;
+    print lc $self->message, "\n";
+};
+
 sub run {
     my ($self) = @_;
     print $self->message, "\n";


### PR DESCRIPTION
This fixes a regression after lazy subcommand loading feature in <https://github.com/arodland/CLI-Osprey/pull/21>.