### PR TITLE
Test hyphenated option

### DIFF
--- a/lib/CLI/Osprey/Role.pm
+++ b/lib/CLI/Osprey/Role.pm
@@ -96,10 +96,10 @@ sub _osprey_fix_argv {
     my $option_name;
     
     if ($dash eq '--') {
-      my $option_name = $abbreviations->{$arg_name_without_dash};
-      if (defined $option_name) {
-        if (@$option_name == 1) {
-          $option_name = $option_name->[0];
+      my $option_names = $abbreviations->{$arg_name_without_dash};
+      if (defined $option_names) {
+        if (@$option_names == 1) {
+          $option_name = $option_names->[0];
         } else {
           # TODO: can't we produce a warning saying that it's ambiguous and which options conflict?
           $option_name = undef;

--- a/t/basic.t
+++ b/t/basic.t
@@ -41,6 +41,15 @@ subtest 'subcommand' => sub {
 	is ( $stderr, '', "empty stderr" );
     };
 
+    subtest "hyphenated options" => sub {
+	local @ARGV = qw ( yell --excitement-level 2 );
+	my ( $stdout, $stderr, @result ) =
+	   capture { MyTest::Class::Basic->new_with_options->run };
+
+	is ( $stdout, "HELLO WORLD!!!\n", "message sent to stdout" );
+	is ( $stderr, '', "empty stderr" );
+    };
+
     subtest "inline" => sub {
 	local @ARGV = qw ( whisper );
 	my ( $stdout, $stderr, @result ) =

--- a/t/lib/MyTest/Class/Basic/Yell.pm
+++ b/t/lib/MyTest/Class/Basic/Yell.pm
@@ -3,9 +3,16 @@ package MyTest::Class::Basic::Yell;
 use Moo;
 use CLI::Osprey;
 
+option excitement_level => (
+    is => 'ro',
+    format => 'i',
+    doc => 'Level of excitement for yelling',
+    default => 0,
+);
+
 sub run {
     my ($self) = @_;
-    print uc $self->parent_command->message, "\n";
+    print uc $self->parent_command->message, "!" x $self->excitement_level, "\n";
 }
 
 


### PR DESCRIPTION
This tests the default transformation of replacing underscores with hyphens.

The current PR fails this test. I wanted to open this for a discussion of potential fixes. I noticed that in commit 2c1ae42c16c67912f3c32ece8aeb1e55c2bd9def, it uses the key `$option` instead of the transformed name `$options->{$option}{option}`. This also causes a bug in the output of the usage where it still contains underscores:

```
Usage: basic.t yell [-h] [--excitement_level int] -h --help --man at lib/CLI/Osprey/Descriptive/Usage.pm line 329.
```

though the output of using `--help` and `--man` is correctly using the hyphen for the option name.