### PR TITLE
fix: Use CLI option name instead of attribute name

### DIFF
--- a/lib/CLI/Osprey/Role.pm
+++ b/lib/CLI/Osprey/Role.pm
@@ -75,7 +75,7 @@ sub _osprey_prepare_options {
     if ($config->{abbreviate}) {
       for my $len (1 .. length($name) - 1) {
         my $abbreviated = substr $name, 0, $len;
-        push @{ $abbreviations{$abbreviated} }, $name unless exists $fullnames{$abbreviated};
+        push @{ $abbreviations{$abbreviated} }, $option unless exists $fullnames{$abbreviated};
       }
     }
   }

--- a/lib/CLI/Osprey/Role.pm
+++ b/lib/CLI/Osprey/Role.pm
@@ -14,11 +14,16 @@ use CLI::Osprey::Descriptive;
 
 sub _osprey_option_to_getopt {
   my ($name, %attributes) = @_;
-  my $getopt = join('|', grep defined, ($name, $attributes{short}));
+
+  # Use custom option name if provided, otherwise use attribute name
+  my $option_name = $attributes{option} || $name;
+
+  my $getopt = join('|', grep defined, ($option_name, $attributes{short}));
   $getopt .= '+' if $attributes{repeatable} && !defined $attributes{format};
   $getopt .= '!' if $attributes{negatable};
   $getopt .= '=' . $attributes{format} if defined $attributes{format};
   $getopt .= '@' if $attributes{repeatable} && defined $attributes{format};
+
   return $getopt;
 }
 

--- a/lib/CLI/Osprey/Role.pm
+++ b/lib/CLI/Osprey/Role.pm
@@ -132,9 +132,12 @@ sub _osprey_fix_argv {
       }
     }
 
+    # $option_name is the attribute name (underscored) from abbreviations table
+    # We need to get the actual CLI option name for the rewritten ARGV
     my $arg_name = ($dash || '') . ($negative || '');
     if (defined $option_name) {
-      $arg_name .= $option_name;
+      # Use the custom option name from the options hash if possible
+      $arg_name .= $options->{$option_name}{option} || $option_name;
     } else {
       $arg_name .= $arg_name_without_dash;
     }

--- a/lib/CLI/Osprey/Role.pm
+++ b/lib/CLI/Osprey/Role.pm
@@ -282,7 +282,15 @@ sub parse_options {
   my %parsed_params;
 
   for my $name (keys %options, qw(h help man)) {
-    my $val = $opt->$name();
+    # Getopt::Long converts hyphens to underscores; Getopt::Long::Descriptive uses these as method names
+    # For custom option names, we need to retrieve using the option name, not attribute name
+    my $method_name = $name;
+    if (exists $options{$name} && exists $options{$name}{option}) {
+      $method_name = $options{$name}{option};
+      $method_name =~ tr/-/_/;  # Convert hyphens to underscores to match Getopt::Long's conversion
+    }
+
+    my $val = $opt->$method_name();
     $parsed_params{$name} = $val if defined $val;
   }
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -158,6 +158,28 @@ subtest 'subcommand' => sub {
                                  "abbreviated --output-form works for --output-format");
             };
         };
+
+        subtest "combinations" => sub {
+            subtest "minimum failing case: short + hyphenated long" => sub {
+                $test_yell_command->([qw(-f xml --excitement-level 2)],
+                                 qr{\Q<yell>HELLO WORLD!!!</yell>\E},
+                                 "XML format via -f with excitement-level 2");
+            };
+
+            subtest "multiple hyphenated long options" => sub {
+                my ($stdout, $stderr) = $run_yell_command->(qw(--excitement-level 2 --output-format xml --repeat-count 2));
+                my @lines = split /\n/, $stdout;
+                is ( scalar(@lines), 2, "repeated 2 times" );
+                like ( $lines[0], qr{\Q<yell>HELLO WORLD!!!</yell>\E}, "XML with excitement-level 2" );
+                is ( $stderr, '', "empty stderr" );
+            };
+
+            subtest "custom option + other options" => sub {
+                $test_yell_command->([qw(-f xml --add-suffix), '[ZAP]', qw(--excitement-level 1)],
+                                 qr{\Q<yell>HELLO WORLD!![ZAP]</yell>\E},
+                                 "custom suffix combined with format and excitement");
+            };
+        };
     };
 
     subtest "inline subcommand" => sub {

--- a/t/basic.t
+++ b/t/basic.t
@@ -126,6 +126,26 @@ subtest 'subcommand' => sub {
                                  "custom suffix added via --add-suffix");
             };
         };
+
+        subtest "add_tag option (negatable)" => sub {
+            subtest "internal: generates hyphenated negatable getopt string" => sub {
+                my $getopt = $get_getopt_string->('add_tag');
+                like($getopt, qr{\Qadd-tag!\E}, "generates hyphenated negatable getopt string");
+                unlike($getopt, qr{\Qadd_tag\E}, "does not generate underscored getopt string");
+            };
+
+            subtest "functional: --add-tag" => sub {
+                $test_yell_command->([qw(--add-tag)], qr{\Q[TAG] HELLO WORLD!\E},
+                                 "tag added via --add-tag");
+            };
+
+            subtest "functional: --no-add-tag" => sub {
+                my ($stdout, $stderr) = $run_yell_command->(qw(--no-add-tag));
+                unlike($stdout, qr{\Q[TAG]\E}, "no tag when disabled via --no-add-tag");
+                like($stdout, qr{^\QHELLO WORLD!\E$}, "plain output");
+                is($stderr, '', "empty stderr");
+            };
+        };
     };
 
     subtest "inline subcommand" => sub {

--- a/t/basic.t
+++ b/t/basic.t
@@ -67,6 +67,24 @@ subtest 'subcommand' => sub {
             $test_yell_command->([], qr{^\QHELLO WORLD!\E\n$}, "message sent to stdout");
         };
 
+        subtest "output_format option" => sub {
+            subtest "internal: generates hyphenated getopt string" => sub {
+                my $getopt = $get_getopt_string->('output_format');
+                like($getopt, qr{\Qoutput-format\E}, "generates hyphenated getopt string");
+                unlike($getopt, qr{\Qoutput_format\E}, "does not generate underscored getopt string");
+            };
+
+            subtest "functional: --output-format long option" => sub {
+                $test_yell_command->([qw(--output-format xml)], qr{\Q<yell>HELLO WORLD!</yell>\E},
+                                 "XML format output");
+            };
+
+            subtest "functional: -f short option" => sub {
+                $test_yell_command->([qw(-f json)], qr{\Q"yell": "HELLO WORLD!"\E},
+                                 "JSON format output");
+            };
+        };
+
         subtest "excitement_level option" => sub {
             subtest "internal: generates hyphenated getopt string" => sub {
                 my $getopt = $get_getopt_string->('excitement_level');

--- a/t/basic.t
+++ b/t/basic.t
@@ -97,6 +97,16 @@ subtest 'subcommand' => sub {
                                  "excitement level adds exclamation marks");
             };
         };
+
+        subtest "repeat_count option" => sub {
+            subtest "functional: -r short option" => sub {
+                my ($stdout, $stderr) = $run_yell_command->(qw(-r 3));
+                my @lines = split /\n/, $stdout;
+                is ( scalar(@lines), 3, "repeated 3 times" );
+                is ( $lines[0], "HELLO WORLD!", "first line correct" );
+                is ( $stderr, '', "empty stderr" );
+            };
+        };
     };
 
     subtest "inline subcommand" => sub {

--- a/t/basic.t
+++ b/t/basic.t
@@ -9,22 +9,22 @@ use MyTest::Class::Basic;
 subtest 'command' => sub {
 
     subtest "default options" => sub {
-	local @ARGV = ();
-	my ( $stdout, $stderr, @result ) =
-	   capture { MyTest::Class::Basic->new_with_options->run };
+        local @ARGV = ();
+        my ( $stdout, $stderr, @result ) =
+           capture { MyTest::Class::Basic->new_with_options->run };
 
-	is ( $stdout, "Hello world!\n", "message sent to stdout" );
-	is ( $stderr, '', "empty stderr" );
+        is ( $stdout, "Hello world!\n", "message sent to stdout" );
+        is ( $stderr, '', "empty stderr" );
 
     };
 
     subtest "command line options" => sub {
-	local @ARGV = ( '--message', 'Hello Cleveland!' );
-	my ( $stdout, $stderr, @result ) =
-	   capture { MyTest::Class::Basic->new_with_options->run };
+        local @ARGV = ( '--message', 'Hello Cleveland!' );
+        my ( $stdout, $stderr, @result ) =
+           capture { MyTest::Class::Basic->new_with_options->run };
 
-	is ( $stdout, "Hello Cleveland!\n", "message sent to stdout" );
-	is ( $stderr, '', "empty stderr" );
+        is ( $stdout, "Hello Cleveland!\n", "message sent to stdout" );
+        is ( $stderr, '', "empty stderr" );
 
     };
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -32,6 +32,19 @@ subtest 'command' => sub {
 
 subtest 'subcommand' => sub {
     subtest 'yell class subcommand' => sub {
+        require CLI::Osprey::Role;
+        require MyTest::Class::Basic::Yell;
+        my %options = MyTest::Class::Basic::Yell->_osprey_options();
+
+        # Helper function: get getopt string for an option
+        my $get_getopt_string = sub {
+            my ($option_name) = @_;
+            my %attrs = %{ $options{$option_name} };
+            my $getopt = CLI::Osprey::Role::_osprey_option_to_getopt($option_name, %attrs);
+            note("$option_name getopt string: $getopt");
+            return $getopt;
+        };
+
         # Helper function: run yell command and capture output
         my $run_yell_command = sub {
             my (@args) = @_;
@@ -55,6 +68,12 @@ subtest 'subcommand' => sub {
         };
 
         subtest "excitement_level option" => sub {
+            subtest "internal: generates hyphenated getopt string" => sub {
+                my $getopt = $get_getopt_string->('excitement_level');
+                like($getopt, qr{\Qexcitement-level\E}, "generates hyphenated getopt string");
+                unlike($getopt, qr{\Qexcitement_level\E}, "does not generate underscored getopt string");
+            };
+
             subtest "functional: --excitement-level" => sub {
                 $test_yell_command->([qw(--excitement-level 2)], qr{^\QHELLO WORLD!!!\E\n$},
                                  "excitement level adds exclamation marks");

--- a/t/basic.t
+++ b/t/basic.t
@@ -146,6 +146,18 @@ subtest 'subcommand' => sub {
                 is($stderr, '', "empty stderr");
             };
         };
+
+        subtest "abbreviate feature" => sub {
+            subtest "--out abbreviates --output-format" => sub {
+                $test_yell_command->([qw(--out xml)], qr{\Q<yell>HELLO WORLD!</yell>\E},
+                                 "abbreviated --out works for --output-format");
+            };
+
+            subtest "--output-form abbreviates --output-format" => sub {
+                $test_yell_command->([qw(--output-form xml)], qr{\Q<yell>HELLO WORLD!</yell>\E},
+                                 "abbreviated --output-form works for --output-format");
+            };
+        };
     };
 
     subtest "inline subcommand" => sub {

--- a/t/basic.t
+++ b/t/basic.t
@@ -107,6 +107,25 @@ subtest 'subcommand' => sub {
                 is ( $stderr, '', "empty stderr" );
             };
         };
+
+        subtest "custom_suffix option (custom option name)" => sub {
+            subtest "internal: generates custom option name getopt string" => sub {
+                my $getopt = $get_getopt_string->('custom_suffix');
+                like($getopt, qr{\Qadd-suffix\E}, "generates custom 'add-suffix' getopt string");
+                unlike($getopt, qr{custom[_-]suffix}, "does not generate attribute name in getopt string");
+                is($getopt, 'add-suffix|s=s', "complete getopt string uses custom option name");
+            };
+
+            subtest "functional: -s short option" => sub {
+                $test_yell_command->([qw(-s), '[BOOM]'], qr{\QHELLO WORLD![BOOM]\E},
+                                 "custom suffix added via -s");
+            };
+
+            subtest "functional: --add-suffix long option" => sub {
+                $test_yell_command->([qw(--add-suffix), '[POW]'], qr{\QHELLO WORLD![POW]\E},
+                                 "custom suffix added via --add-suffix");
+            };
+        };
     };
 
     subtest "inline subcommand" => sub {

--- a/t/lib/MyTest/Class/Basic/Yell.pm
+++ b/t/lib/MyTest/Class/Basic/Yell.pm
@@ -20,20 +20,31 @@ option output_format => (
     default => 'text',
 );
 
+# Another example with short option matching first letter
+option repeat_count => (
+    is => 'ro',
+    format => 'i',
+    short => 'r',  # Matches first letter of long option name
+    doc => 'Number of times to repeat the yell',
+    default => 1,
+);
+
 sub run {
     my ($self) = @_;
     my $message = uc $self->parent_command->message . "!" x $self->excitement_level;
 
-    my $output;
-    if ($self->output_format eq 'json') {
-        $output = qq({"yell": "$message"});
-    } elsif ($self->output_format eq 'xml') {
-        $output = qq(<yell>$message</yell>);
-    } else {
-        $output = $message;
-    }
+    for (1 .. $self->repeat_count) {
+        my $output;
+        if ($self->output_format eq 'json') {
+            $output = qq({"yell": "$message"});
+        } elsif ($self->output_format eq 'xml') {
+            $output = qq(<yell>$message</yell>);
+        } else {
+            $output = $message;
+        }
 
-    print "$output\n";
+        print "$output\n";
+    }
 }
 
 

--- a/t/lib/MyTest/Class/Basic/Yell.pm
+++ b/t/lib/MyTest/Class/Basic/Yell.pm
@@ -39,6 +39,14 @@ option custom_suffix => (
     default => '',
 );
 
+# Negatable boolean option - no format!
+option add_tag => (
+    is => 'ro',
+    negatable => 1,
+    doc => 'Add tag to output',
+    default => 0,
+);
+
 sub run {
     my ($self) = @_;
     my $message = uc $self->parent_command->message . "!" x $self->excitement_level;
@@ -56,7 +64,11 @@ sub run {
             $output = $message;
         }
 
-        print "$output\n";
+        if ($self->add_tag) {
+            print "[TAG] $output\n";
+        } else {
+            print "$output\n";
+        }
     }
 }
 

--- a/t/lib/MyTest/Class/Basic/Yell.pm
+++ b/t/lib/MyTest/Class/Basic/Yell.pm
@@ -29,9 +29,22 @@ option repeat_count => (
     default => 1,
 );
 
+# Test with completely different option name from attribute
+option custom_suffix => (
+    is => 'ro',
+    format => 's',
+    option => 'add-suffix',  # Completely different from attribute name!
+    short => 's',
+    doc => 'Custom suffix to add to output',
+    default => '',
+);
+
 sub run {
     my ($self) = @_;
     my $message = uc $self->parent_command->message . "!" x $self->excitement_level;
+
+    # Add custom suffix if provided
+    $message .= $self->custom_suffix if $self->custom_suffix;
 
     for (1 .. $self->repeat_count) {
         my $output;

--- a/t/lib/MyTest/Class/Basic/Yell.pm
+++ b/t/lib/MyTest/Class/Basic/Yell.pm
@@ -10,9 +10,30 @@ option excitement_level => (
     default => 0,
 );
 
+# Example of underscored attribute name with short option that doesn't match first letter
+# Tests the fix where option name becomes 'output-format' (hyphenated)
+option output_format => (
+    is => 'ro',
+    format => 's',
+    short => 'f',  # Note: 'f' not 'o' - doesn't match first letter
+    doc => 'Output format (text, json, xml)',
+    default => 'text',
+);
+
 sub run {
     my ($self) = @_;
-    print uc $self->parent_command->message, "!" x $self->excitement_level, "\n";
+    my $message = uc $self->parent_command->message . "!" x $self->excitement_level;
+
+    my $output;
+    if ($self->output_format eq 'json') {
+        $output = qq({"yell": "$message"});
+    } elsif ($self->output_format eq 'xml') {
+        $output = qq(<yell>$message</yell>);
+    } else {
+        $output = $message;
+    }
+
+    print "$output\n";
 }
 
 


### PR DESCRIPTION
Throughout the code the `option` key on the attributes was not being used
consistently.

This fixes that and tests it against several features.

Continuation of <https://github.com/arodland/CLI-Osprey/pull/28>.